### PR TITLE
Collect gateway API Inference Extension resources (#5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,7 @@ You will get a dump of:
 - All Kiali CRD objects (Kiali, ossmconsole)
 - All gateway.networking.k8s.io group CRD definitions
 - All gateway.networking.k8s.io group instances
+- All inference.networking.x-k8s.io group CRD definitions
+- All inference.networking.x-k8s.io group instances
 
 In order to get data about other parts of the cluster (not specific to service mesh) you should run just `oc adm must-gather` (without passing a custom image). Run `oc adm must-gather -h` to see more options.

--- a/gather_istio.sh
+++ b/gather_istio.sh
@@ -31,11 +31,11 @@ get_log_collection_args() {
   fi
 }
 
-# Get Istio, sail operator, kiali and gateway.networking.k8s.io group CRDs
+# Get Istio, sail operator, kiali, gateway.networking.k8s.io and inference.networking.x-k8s.io group CRDs
 function getCRDs() {
   local result=()
   local output
-  output=$(oc get crds -o custom-columns=NAME:metadata.name --no-headers | grep -e '\.istio\.io' -e '\.sailoperator\.io' -e '\.kiali\.io' -e '\.gateway\.networking\.k8s\.io')
+  output=$(oc get crds -o custom-columns=NAME:metadata.name --no-headers | grep -e '\.istio\.io' -e '\.sailoperator\.io' -e '\.kiali\.io' -e '\.gateway\.networking\.k8s\.io' -e 'inference\.networking\.x-k8s\.io')
   for crd in ${output}; do
     result+=("${crd}")
   done
@@ -182,7 +182,7 @@ function main() {
     inspect "$r"
   done
 
-  # inspect all istio, sail operator, kiali and gateway API CRDs
+  # inspect all istio, sail operator, kiali and gateway API+ CRDs
   # this will also collect instances of those CRDs
   crds="$(getCRDs)"
   for crd in ${crds}; do


### PR DESCRIPTION
This adds all CRDs from inference.networking.x-k8s.io group and their instances to the must gather.